### PR TITLE
Adding new code to handle Exploit-DB CVE different HTML printings

### DIFF
--- a/epherousa/searchers/ExploitDB.py
+++ b/epherousa/searchers/ExploitDB.py
@@ -27,6 +27,20 @@ class ExploitDB(Searcher):
     _ID_TO_CVE_URL = 'https://cve.mitre.org/data/refs/refmap/source-EXPLOIT-DB.html'
     _DESCRIPTION = 'Searches for exploits at https://www.exploit-db.com'
 
+    @staticmethod
+    def _format_cve(cve):
+
+        if cve == "N/A": return cve
+        # if only 1 CVE in the list
+        if len(cve) <= 1 and len(cve[0]) <= 13:
+            return cve[0]
+
+        cves = list(set(cve))
+        tmp = cves[0]
+        for i in cves[1:]:
+            tmp += ',{}'.format(i)
+        return tmp
+
     def setup(self, search_by_string=True):
         """Setup method used for initialisation purposes by every Scanner."""
         super(ExploitDB, self).setup()
@@ -49,20 +63,25 @@ class ExploitDB(Searcher):
             exploit.cve = self.cve
         else:
             # try to fetch the CVE from Exploit's page
-            exploit.cve = self.fetch_cve(exploit)
+            exploit.cve = self._format_cve(self.fetch_cve(exploit))
         return exploit
 
     def fetch_cve(self, exploit):
-        """Scraps Exploit-DBs website to fetch the exploit's CVE."""
+        """Scrapes Exploit-DBs website to fetch the exploit's CVE."""
         try:
             html = self.session.get(exploit.url)
             soup = BeautifulSoup(html.content, 'html.parser')
             start_table = soup.find_all('table', class_='exploit_list')
-            cve = start_table[0].find_all('a', string=re.compile('CVE-\d{4}-\d{4,7}'))
+            cve = start_table[0].find_all('a', string=self._CVE_PATTERN)
             for i in cve:
-                for j in i.contents:
-                    if self._CVE_PATTERN.search(j):
-                        return j.strip()
+                if 'data-content' in i.attrs:
+                # this is due to weird HTML/JS stuff in exploit-db site
+                    return [c.group(0) for c in self._CVE_PATTERN.finditer(i.attrs['data-content'])]
+                else:
+                # exploit-db has 1 CVE only
+                    for j in i.contents:
+                        if self._CVE_PATTERN.search(j):
+                            return [j.strip()]
         except Timeout as e:
             self.log.warn("Timed out while requesting {}: {}".format(exploit.url, e))
             return "N/A"

--- a/epherousa/searchers/ExploitDB.py
+++ b/epherousa/searchers/ExploitDB.py
@@ -29,13 +29,12 @@ class ExploitDB(Searcher):
 
     @staticmethod
     def _format_cve(cve):
-
-        if cve == "N/A": return cve
+        if not cve: return cve
         # if only 1 CVE in the list
         if len(cve) <= 1 and len(cve[0]) <= 13:
             return cve[0]
 
-        cves = list(set(cve))
+        cves = [set(cve)]
         tmp = cves[0]
         for i in cves[1:]:
             tmp += ',{}'.format(i)


### PR DESCRIPTION
This should fix #51 bug, however I don't like how I've written the format cve method. We need to improve these ones as issues like that will arise all the time. Check for duplicates, check for weird characters in CVEs, and most importantly have variable type consistency I think.

In this case, I return "N/A" which is a string some times, while the other times its a list. Also, shouldn't all the searchers return the exact same thing when there is no exploit available?